### PR TITLE
Update provider.php

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,7 +24,7 @@
  * @author    Luuk Verhoeven
  **/
 
-namespace local_commander\privacy;
+namespace tool_groupautoenrol\privacy;
 
 /**
  * Class provider


### PR DESCRIPTION
When requesting GDPR data export or deletion, this unmatching namespace leads to crash the cron job.